### PR TITLE
Add codeowners team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
-# Global code owners - RUM Mobile Team
+# CODEOWNERS file
+# This file defines the default code owners for this repository.
+# Code owners are automatically requested for review when someone opens a pull request.
 
-* @DataDog/rum-mobile @DataDog/rum-mobile-android
-
-## Docs
-
-/docs/ @DataDog/documentation @DataDog/rum-mobile 
-*README.md @DataDog/documentation @DataDog/rum-mobile 
+# Default owner for everything in the repo
+* @porterin/cest-core-engineering-codeowners @porterin/cest-central-eng-codeowners


### PR DESCRIPTION
## Summary
This PR adds the codeowners teams to the CODEOWNERS file for this orphan repository.

## Changes
- Updated CODEOWNERS file
- Added `@porterin/cest-core-engineering-codeowners` as code owner
- Added `@porterin/cest-central-eng-codeowners` as code owner

## Notes
- This ensures the core engineering codeowners teams are automatically requested for review on all PRs
- Generated automatically by GitHub automation

🤖 Generated with automation